### PR TITLE
Add support for POST /startwalk endpoint

### DIFF
--- a/restserver.py
+++ b/restserver.py
@@ -112,7 +112,7 @@ async def change_pad_mode():
         await asyncio.sleep(1.0)
     finally:
         await disconnect()
-    
+
     return new_mode
 
 
@@ -131,7 +131,23 @@ async def get_history():
 @app.route("/save", methods=['POST'])
 def save():
     store_in_db(last_status['steps'], last_status['distance'], last_status['time'])
-    
+
+@app.route("/startwalk", methods=['POST'])
+async def start_walk():
+    try:
+        await connect()
+        await ctler.switch_mode(WalkingPad.MODE_STANDBY) # Ensure we start from a known state, since start_belt is actually toggle_belt
+        await asyncio.sleep(ctler.minimal_cmd_space)
+        await ctler.switch_mode(WalkingPad.MODE_MANUAL)
+        await asyncio.sleep(ctler.minimal_cmd_space)
+        await ctler.start_belt()
+        await asyncio.sleep(ctler.minimal_cmd_space)
+        await ctler.ask_hist(0)
+        await asyncio.sleep(ctler.minimal_cmd_space)
+    finally:
+        await disconnect()
+    return last_status
+
 @app.route("/finishwalk", methods=['POST'])
 async def finish_walk():
     try:


### PR DESCRIPTION
This endpoint ensures that the walkingpad is in manual mode and idle before toggling the motor.