### PR TITLE
Avoid multiple concurrent requests

### DIFF
--- a/restserver.py
+++ b/restserver.py
@@ -150,4 +150,4 @@ async def finish_walk():
 ctler.handler_last_status = on_new_status
 
 if __name__ == '__main__':
-    app.run(debug=True, host='0.0.0.0', port=5678)
+    app.run(debug=True, host='0.0.0.0', port=5678, processes=1, threaded=False)


### PR DESCRIPTION
Multiple concurrent requests were being allowed, which would break the Bluetooth connection state.